### PR TITLE
Upgrade chat gpt version

### DIFF
--- a/src/node/olympe/GPTCodeGenerationAPI.js
+++ b/src/node/olympe/GPTCodeGenerationAPI.js
@@ -21,7 +21,9 @@ export default class GPTCodeGenerationAPI extends ActionBrick {
             apiKey: Config.getParameter('openai.apiKey')
         });
         const openai = new OpenAIApi(configuration);
-        const model = 'text-davinci-003';
+        // this is legacy completion https://platform.openai.com/docs/guides/text-generation/completions-api
+        // chat endpoint can be used as well with a different payload
+        const model = 'gpt-3.5-turbo-instruct';
         const prompt = this.createPrompt(shortDescription, longDescription, inputs, outputs);
         const answer = await openai.createCompletion({
             model: model,

--- a/src/node/olympe/GPTCompletion.js
+++ b/src/node/olympe/GPTCompletion.js
@@ -30,8 +30,10 @@ export default class GPTCompletion extends ActionBrick {
             return;
         }
         let aiModel = model;
+        // for completion https://platform.openai.com/docs/guides/text-generation/completions-api
+        // the "chatting" model can be used for single instructions as well, which has not history except the current prompt
         if (model === 'default') {
-            aiModel = chatting ? 'gpt-3.5-turbo' : 'text-davinci-003';
+            aiModel = chatting ? 'gpt-3.5-turbo' : 'gpt-3.5-turbo-instruct';
         }
         const configuration = new Configuration({
             organization: Config.getParameter('openai.organization'),


### PR DESCRIPTION
Upgrading the version used for the model used by openai endpoints as by 4th January 2024, text-davinci-003 will be taken out of service. 